### PR TITLE
Fix time bug

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -98,7 +98,7 @@ function parseData(response) {
         };
 
         // Time is not always present
-        if (!event.dates.start.timeTBA) {
+        if (!event.dates.start.timeTBA && !event.dates.start.noSpecificTime) {
           data[id].time = event.dates.start.localTime;
         }
 


### PR DESCRIPTION
- When `noSpecificTime` is true it probably means it's an all-day event.